### PR TITLE
Stoch fix reg test logs etc

### DIFF
--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Tue Nov 24 09:54:19 MST 2020
+Thu Nov 26 13:17:36 MST 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v16beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -186,8 +186,8 @@ Checking test 003 fv3_ccpp_gfs_v16beta results ....
 Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v16beta_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -254,8 +254,8 @@ Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
 Test 004 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 005 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -322,8 +322,8 @@ Checking test 005 fv3_ccpp_gfs_v15p2_RRTMGP results ....
 Test 005 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 006 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_gfs_v16beta_RRTMGP results ....
 Test 006 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gsd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gsd_prod
 Checking test 007 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -482,8 +482,8 @@ Checking test 007 fv3_ccpp_gsd results ....
 Test 007 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_thompson_prod
 Checking test 008 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -550,8 +550,8 @@ Checking test 008 fv3_ccpp_thompson results ....
 Test 008 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_thompson_no_aero_prod
 Checking test 009 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -618,8 +618,8 @@ Checking test 009 fv3_ccpp_thompson_no_aero results ....
 Test 009 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_rrfs_v1beta_prod
 Checking test 010 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -686,8 +686,8 @@ Checking test 010 fv3_ccpp_rrfs_v1beta results ....
 Test 010 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 011 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -754,8 +754,8 @@ Checking test 011 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 011 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -772,8 +772,8 @@ Checking test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 012 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_control_debug_prod
 Checking test 013 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -802,8 +802,8 @@ Checking test 013 fv3_ccpp_control_debug results ....
 Test 013 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 014 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -870,8 +870,8 @@ Checking test 014 fv3_ccpp_gfs_v15p2_debug results ....
 Test 014 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v16beta_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v16beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 015 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -938,8 +938,8 @@ Checking test 015 fv3_ccpp_gfs_v16beta_debug results ....
 Test 015 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
 Test 016 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1074,8 +1074,8 @@ Checking test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
 Test 017 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_multigases_prod
 Checking test 018 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1148,8 +1148,8 @@ Checking test 018 fv3_ccpp_multigases results ....
 Test 018 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1216,8 +1216,8 @@ Checking test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
 Test 019 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_22144/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_14276/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1235,5 +1235,5 @@ Test 020 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Nov 24 10:11:29 MST 2020
-Elapsed time: 00h:17m:10s. Have a nice day!
+Thu Nov 26 13:33:44 MST 2020
+Elapsed time: 00h:16m:09s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Tue Nov 24 13:00:04 MST 2020
+Thu Nov 26 15:29:22 MST 2020
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_read_inc_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -447,10 +447,10 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,75 +631,75 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
+ Comparing phyf000.tile1.nc ............ALT CHECK......OK
+ Comparing phyf000.tile2.nc ............ALT CHECK......OK
+ Comparing phyf000.tile3.nc ............ALT CHECK......OK
+ Comparing phyf000.tile4.nc ............ALT CHECK......OK
+ Comparing phyf000.tile5.nc ............ALT CHECK......OK
+ Comparing phyf000.tile6.nc ............ALT CHECK......OK
+ Comparing phyf012.tile1.nc ............ALT CHECK......OK
+ Comparing phyf012.tile2.nc ............ALT CHECK......OK
+ Comparing phyf012.tile3.nc ............ALT CHECK......OK
+ Comparing phyf012.tile4.nc ............ALT CHECK......OK
+ Comparing phyf012.tile5.nc ............ALT CHECK......OK
+ Comparing phyf012.tile6.nc ............ALT CHECK......OK
+ Comparing dynf000.tile1.nc ............ALT CHECK......OK
+ Comparing dynf000.tile2.nc ............ALT CHECK......OK
+ Comparing dynf000.tile3.nc ............ALT CHECK......OK
+ Comparing dynf000.tile4.nc ............ALT CHECK......OK
+ Comparing dynf000.tile5.nc ............ALT CHECK......OK
+ Comparing dynf000.tile6.nc ............ALT CHECK......OK
+ Comparing dynf012.tile1.nc ............ALT CHECK......OK
+ Comparing dynf012.tile2.nc ............ALT CHECK......OK
+ Comparing dynf012.tile3.nc ............ALT CHECK......OK
+ Comparing dynf012.tile4.nc ............ALT CHECK......OK
+ Comparing dynf012.tile5.nc ............ALT CHECK......OK
+ Comparing dynf012.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/sfc_data.tile6.nc ............ALT CHECK......OK
 Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_iau_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_iau_prod
 Checking test 013 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_iau PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_ca_prod
 Checking test 014 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_lheatstrg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_lheatstrg_prod
 Checking test 015 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -883,7 +883,7 @@ Test 015 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_multigases_prod
 Checking test 016 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -957,7 +957,7 @@ Test 016 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_control_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_control_32bit_prod
 Checking test 017 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1025,7 +1025,7 @@ Test 017 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_stretched_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_stretched_prod
 Checking test 018 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1081,7 +1081,7 @@ Test 018 fv3_ccpp_stretched PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_stretched_nest_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_stretched_nest_prod
 Checking test 019 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1148,7 +1148,7 @@ Test 019 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_regional_control_prod
 Checking test 020 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1159,7 +1159,7 @@ Test 020 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_regional_restart_prod
 Checking test 021 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1168,7 +1168,7 @@ Test 021 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_regional_quilt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_regional_quilt_prod
 Checking test 022 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1179,18 +1179,18 @@ Test 022 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 023 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 Test 023 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_control_debug_prod
 Checking test 024 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1220,7 +1220,7 @@ Test 024 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_stretched_nest_debug_prod
 Checking test 025 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1240,7 +1240,7 @@ Test 025 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfdlmp_prod
 Checking test 026 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 026 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 027 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1336,7 +1336,7 @@ Test 027 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 028 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1384,7 +1384,7 @@ Test 028 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_csawmg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_csawmg_prod
 Checking test 029 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1432,7 +1432,7 @@ Test 029 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_satmedmf_prod
 Checking test 030 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1480,7 +1480,7 @@ Test 030 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_satmedmfq_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_satmedmfq_prod
 Checking test 031 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1528,7 +1528,7 @@ Test 031 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1576,7 +1576,7 @@ Test 032 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1628,7 +1628,7 @@ Test 033 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_cpt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_cpt_prod
 Checking test 034 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1682,7 +1682,7 @@ Test 034 fv3_ccpp_cpt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gsd_prod
 Checking test 035 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1774,7 +1774,7 @@ Test 035 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_thompson_prod
 Checking test 036 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 036 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_thompson_no_aero_prod
 Checking test 037 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 037 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_rrfs_v1beta_prod
 Checking test 038 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 038 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v15p2_prod
 Checking test 039 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 039 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v16beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v16beta_prod
 Checking test 040 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 040 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 041 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 041 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 042 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2250,7 +2250,7 @@ Test 042 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gocart_clm_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gocart_clm_prod
 Checking test 043 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2298,7 +2298,7 @@ Test 043 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2366,7 +2366,7 @@ Test 044 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 045 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2434,7 +2434,7 @@ Test 045 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 046 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2452,7 +2452,7 @@ Test 046 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2520,7 +2520,7 @@ Test 047 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 048 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2588,7 +2588,7 @@ Test 048 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 049 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2656,7 +2656,7 @@ Test 049 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gsd_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gsd_debug_prod
 Checking test 050 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2724,7 +2724,7 @@ Test 050 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 051 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2792,7 +2792,7 @@ Test 051 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_thompson_debug_prod
 Checking test 052 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2860,7 +2860,7 @@ Test 052 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 053 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2928,7 +2928,7 @@ Test 053 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 054 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2996,7 +2996,7 @@ Test 054 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3064,7 +3064,7 @@ Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_64856/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3082,5 +3082,5 @@ Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Nov 24 13:35:40 MST 2020
-Elapsed time: 00h:35m:36s. Have a nice day!
+Thu Nov 26 16:01:08 MST 2020
+Elapsed time: 00h:31m:46s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Tue Nov 24 10:14:28 EST 2020
+Thu Nov 26 17:08:10 EST 2020
 Start Regression test
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_decomp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_restart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_restart_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_read_inc_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_read_inc_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_read_inc_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGauss_netcdf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGauss_nemsio_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -630,8 +630,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_stochy_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_stochy_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -698,8 +698,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_lheatstrg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_lheatstrg_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_lheatstrg_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_lheatstrg_prod
 Checking test 013 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -746,8 +746,8 @@ Checking test 013 fv3_ccpp_lheatstrg results ....
 Test 013 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_multigases_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_multigases_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_multigases_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_multigases_prod
 Checking test 014 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -820,8 +820,8 @@ Checking test 014 fv3_ccpp_multigases results ....
 Test 014 fv3_ccpp_multigases PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_control_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_control_32bit_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_control_32bit_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_control_32bit_prod
 Checking test 015 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -888,8 +888,8 @@ Checking test 015 fv3_ccpp_control_32bit results ....
 Test 015 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_stretched_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_stretched_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_stretched_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_stretched_prod
 Checking test 016 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -944,8 +944,8 @@ Checking test 016 fv3_ccpp_stretched results ....
 Test 016 fv3_ccpp_stretched PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_stretched_nest_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_stretched_nest_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_stretched_nest_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_stretched_nest_prod
 Checking test 017 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1011,8 +1011,8 @@ Checking test 017 fv3_ccpp_stretched_nest results ....
 Test 017 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_regional_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_regional_control_prod
 Checking test 018 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1022,8 +1022,8 @@ Checking test 018 fv3_ccpp_regional_control results ....
 Test 018 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_regional_restart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_regional_restart_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_regional_restart_prod
 Checking test 019 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1031,8 +1031,8 @@ Checking test 019 fv3_ccpp_regional_restart results ....
 Test 019 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_regional_quilt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_regional_quilt_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_regional_quilt_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_regional_quilt_prod
 Checking test 020 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1042,8 +1042,8 @@ Checking test 020 fv3_ccpp_regional_quilt results ....
 Test 020 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 021 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1053,8 +1053,8 @@ Checking test 021 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 021 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_regional_c768_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_regional_c768_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_regional_c768_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_regional_c768_prod
 Checking test 022 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1064,8 +1064,8 @@ Checking test 022 fv3_ccpp_regional_c768 results ....
 Test 022 fv3_ccpp_regional_c768 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_control_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_control_debug_prod
 Checking test 023 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1094,8 +1094,8 @@ Checking test 023 fv3_ccpp_control_debug results ....
 Test 023 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_stretched_nest_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_stretched_nest_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_stretched_nest_debug_prod
 Checking test 024 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1114,8 +1114,8 @@ Checking test 024 fv3_ccpp_stretched_nest_debug results ....
 Test 024 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gfdlmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gfdlmp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gfdlmp_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1162,8 +1162,8 @@ Checking test 025 fv3_ccpp_gfdlmp results ....
 Test 025 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gfdlmprad_gwd_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1210,8 +1210,8 @@ Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
 Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1258,8 +1258,8 @@ Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_csawmg_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_csawmg_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1306,8 +1306,8 @@ Checking test 028 fv3_ccpp_csawmg results ....
 Test 028 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_satmedmf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_satmedmf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1354,8 +1354,8 @@ Checking test 029 fv3_ccpp_satmedmf results ....
 Test 029 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_satmedmfq_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_satmedmfq_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_satmedmfq_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1402,8 +1402,8 @@ Checking test 030 fv3_ccpp_satmedmfq results ....
 Test 030 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gfdlmp_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gfdlmp_32bit_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1450,8 +1450,8 @@ Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
 Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_cpt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_cpt_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_cpt_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_cpt_prod
 Checking test 032 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1504,8 +1504,8 @@ Checking test 032 fv3_ccpp_cpt results ....
 Test 032 fv3_ccpp_cpt PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gsd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gsd_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gsd_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gsd_prod
 Checking test 033 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,8 +1596,8 @@ Checking test 033 fv3_ccpp_gsd results ....
 Test 033 fv3_ccpp_gsd PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_thompson_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_thompson_prod
 Checking test 034 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1664,8 +1664,8 @@ Checking test 034 fv3_ccpp_thompson results ....
 Test 034 fv3_ccpp_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_thompson_no_aero_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_thompson_no_aero_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_thompson_no_aero_prod
 Checking test 035 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1732,8 +1732,8 @@ Checking test 035 fv3_ccpp_thompson_no_aero results ....
 Test 035 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_rrfs_v1beta_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_rrfs_v1beta_prod
 Checking test 036 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1800,8 +1800,8 @@ Checking test 036 fv3_ccpp_rrfs_v1beta results ....
 Test 036 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gocart_clm_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gocart_clm_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gocart_clm_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gocart_clm_prod
 Checking test 037 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1848,8 +1848,8 @@ Checking test 037 fv3_ccpp_gocart_clm results ....
 Test 037 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gfs_v16beta_flake_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gfs_v16beta_flake_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 038 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1916,8 +1916,8 @@ Checking test 038 fv3_ccpp_gfs_v16beta_flake results ....
 Test 038 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 039 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1984,8 +1984,8 @@ Checking test 039 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 039 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 040 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2002,8 +2002,8 @@ Checking test 040 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 040 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gsd_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gsd_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gsd_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gsd_debug_prod
 Checking test 041 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2070,8 +2070,8 @@ Checking test 041 fv3_ccpp_gsd_debug results ....
 Test 041 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_gsd_diag3d_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_gsd_diag3d_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 042 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2138,8 +2138,8 @@ Checking test 042 fv3_ccpp_gsd_diag3d_debug results ....
 Test 042 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_thompson_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_thompson_debug_prod
 Checking test 043 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2206,8 +2206,8 @@ Checking test 043 fv3_ccpp_thompson_debug results ....
 Test 043 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_thompson_no_aero_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_thompson_no_aero_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 044 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2274,8 +2274,8 @@ Checking test 044 fv3_ccpp_thompson_no_aero_debug results ....
 Test 044 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_rrfs_v1beta_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 045 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2342,8 +2342,8 @@ Checking test 045 fv3_ccpp_rrfs_v1beta_debug results ....
 Test 045 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 046 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2410,8 +2410,8 @@ Checking test 046 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
 Test 046 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201124/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_10824/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20201127/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_28003/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 047 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2429,5 +2429,5 @@ Test 047 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Nov 24 10:48:26 EST 2020
-Elapsed time: 00h:33m:59s. Have a nice day!
+Thu Nov 26 17:40:25 EST 2020
+Elapsed time: 00h:32m:16s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -396,9 +396,9 @@ if [[ $TESTS_FILE =~ '35d' ]]; then
 fi
 
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = jet.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20201124/${RT_COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20201127/${RT_COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20201124}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20201127}
 fi
 
 shift $((OPTIND-1))

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -270,7 +270,7 @@ check_results() {
         d=$( cmp ${RTPWD}/${CNTL_DIR}/$i ${RUNDIR}/$i | wc -l )
 
         if [[ $d -ne 0 ]] ; then
-          if [[ ${MACHINE_ID} =~ orion || ${MACHINE_ID} =~ hera || ${MACHINE_ID} =~ wcoss_dell_p3 || ${MACHINE_ID} =~ wcoss_cray || ${MACHINE_ID} =~ cheyenne ]]; then
+          if [[ ${MACHINE_ID} =~ orion || ${MACHINE_ID} =~ hera || ${MACHINE_ID} =~ wcoss_dell_p3 || ${MACHINE_ID} =~ wcoss_cray || ${MACHINE_ID} =~ cheyenne || ${MACHINE_ID} =~ gaea ]]; then
             printf ".......ALT CHECK.." >> ${REGRESSIONTEST_LOG}
             printf ".......ALT CHECK.."
             d=$( ${PATHRT}/compare_ncfile.py ${RTPWD}/${CNTL_DIR}/$i ${RUNDIR}/$i 2>/dev/null | wc -l )


### PR DESCRIPTION
This PR needs to be merged or the branch stoch_fix_dom4phil from https://github.com/climbfuji/ufs-weather-model needs to be pulled in before merging https://github.com/ufs-community/ufs-weather-model/pull/280.

It contains:
- bugfix in `tests/rt_utils.sh` for gaea (similar to what was required for other machines in the last PR because of the failing parallel nctest file comparisons)
- update regression test baseline date in `rt.sh` to 20201127 (this is what was used for regression testing on cheyenne.intel, cheyenne.gnu, gaea.intel)
- regression test logs for cheyenne.intel, cheyenne.gnu, gaea.intel

Thanks!